### PR TITLE
fix(dep): fix golang dep was not installed properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN go get -u \
         golang.org/x/tools/cmd/goimports \
 
         # Semi-official dependency management.
-        github.com/golang/dep \
+        github.com/golang/dep/cmd/dep \
     && rm -rf $GOPATH/src/* && rm -rf $GOPATH/pkg/*
 
 ENV GLIDE_VERSION v0.12.3

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -37,7 +37,7 @@ RUN go get -u \
         golang.org/x/tools/cmd/goimports \
 
         # Semi-official dependency management.
-        github.com/golang/dep \
+        github.com/golang/dep/cmd/dep \
     && rm -rf $GOPATH/src/* && rm -rf $GOPATH/pkg/*
 
 ENV GLIDE_VERSION v0.12.1

--- a/test/mustcompile/mustcompile.go
+++ b/test/mustcompile/mustcompile.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os/exec"
 	"runtime"
 	"strings"
 )
@@ -21,6 +22,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	if err := verifyInstalledTools(); err != nil {
+		log.Fatal(err)
+	}
+
 	fmt.Println("Pass!")
 }
 
@@ -35,4 +40,11 @@ func verifyGoVersion(version string) error {
 	}
 
 	return nil
+}
+
+func verifyInstalledTools() error {
+	// Check `dep version`
+	cmd := exec.Command("dep", "version")
+	_, err := cmd.Output()
+	return err
 }


### PR DESCRIPTION
# What

The `dep` tool was not installed properly, this PR make sure that we install the `dep` tool properly with certain tests.

# Acceptance

Running `dep version` and other `dep` commands should work. See [golang dep](https://github.com/golang/dep)