### PR TITLE
fix(Dockerfile): fix continuation warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,11 @@ ENV OUTDIR /out
 # into the project source code.
 ##########################
 RUN go get -u \
-        # Unit test report generation.
         github.com/jstemmer/go-junit-report \
-        # Coverage report generation.
         github.com/t-yuki/gocover-cobertura \
         github.com/wadey/gocovmerge \
-        # Code analysis tools: golint, goimports.
         github.com/golang/lint/golint \
         golang.org/x/tools/cmd/goimports \
-        # Semi-official dependency management.
         github.com/golang/dep/cmd/dep \
     && rm -rf $GOPATH/src/* && rm -rf $GOPATH/pkg/*
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -25,15 +25,11 @@ ENV OUTDIR /out
 # into the project source code.
 ##########################
 RUN go get -u \
-        # Unit test report generation.
         github.com/jstemmer/go-junit-report \
-        # Coverage report generation.
         github.com/t-yuki/gocover-cobertura \
         github.com/wadey/gocovmerge \
-        # Code analysis tool: golint.
         github.com/golang/lint/golint \
         golang.org/x/tools/cmd/goimports \
-        # Semi-official dependency management.
         github.com/golang/dep/cmd/dep \
     && rm -rf $GOPATH/src/* && rm -rf $GOPATH/pkg/*
 


### PR DESCRIPTION
# Context

Fixes the following warning during `make build`:
```
[WARNING]: Empty continuation line found in:
    RUN go get -u         github.com/jstemmer/go-junit-report         github.com/t-yuki/gocover-cobertura         github.com/wadey/gocovmerge         github.com/golang/lint/golint         golang.org/x/tools/cmd/goimports         github.com/golang/dep/cmd/dep     && rm -rf $GOPATH/src/* && rm -rf $GOPATH/pkg/*
[WARNING]: Empty continuation lines will become errors in a future release.
```