### PR TITLE
chore(deploy.sh): add --all-tags for docker push after Docker 20.10.0

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,4 +9,4 @@ docker tag vungle/golang:${ver}-alpine vungle/golang:${minorver}-alpine
 docker tag vungle/golang:${ver}-alpine vungle/golang:${majorver}-alpine
 
 docker info
-docker push vungle/golang
+docker push --all-tags vungle/golang


### PR DESCRIPTION
Need to add --all-tags for pushing multiple tags after Docker 20.10.0 