### PR TITLE
Pass BUILD_SCOPE to make publish to fix dockerhub tags

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,4 +2,4 @@
 VERSION=`cat .version`
 
 make build BUILD_SCOPE=${VERSION} PUSH_MULTIARCH=true
-make publish
+make publish BUILD_SCOPE=${VERSION}


### PR DESCRIPTION
Overriding BUILD_SCOPE when calling `make publish` during deployment.  Without that change, the tags pushed to dockerhub will be tagged with the `-travis` suffix.