### PR TITLE
chore(CI): Build and push only multi-arch image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Build and publish images
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+      - name: Build and push
+        run: |
+          ./deploy.sh
+  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test images
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+      - name: Build and test
+        run: |
+          make build PUSH_MULTIARCH=true
+  test:
+    needs: build
+    strategy:
+      matrix:
+        runners: [ubuntu-latest, ubuntu-latest-2-core-arm]
+    runs-on: ${{ matrix.runners }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+      - name: Test
+        run: |
+          make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
  - docker --version
 
 script:
-  - make build test
+  - make build test PUSH_MULTIARCH=true
 
 deploy:
   provider: script

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM golang:1.22.4
 # these output files can be consumed by other processes. Downstream projects can
 # choose to mount OUTDIR to a volume directly or create a directory and perform
 # `docker cp ...` later.
-ENV OUTDIR /out
+ENV OUTDIR=/out
 
 ##########################
 # Testing and Tooling

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -15,7 +15,7 @@ RUN apk add -q --update \
 # these output files can be consumed by other processes. Downstream projects can
 # choose to mount OUTDIR to a volume directly or create a directory and perform
 # `docker cp ...` later.
-ENV OUTDIR /out
+ENV OUTDIR=/out
 
 ##########################
 # Testing and Tooling

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 ifndef BUILD_SCOPE
-BUILD_SCOPE=v1.21.5-dev
+BUILD_SCOPE=v1.22.4-dev
 endif
 
 PROJECT_BASE=vungle/golang
+
 
 VERSION            := $(patsubst v%,%,$(BUILD_SCOPE))
 LABEL_PARTS        ?= $(subst -, ,$(VERSION))
@@ -20,41 +21,29 @@ ifeq ($(PUSH_MULTIARCH), true)
 BUILDX_ARG_PUSH = '--push'
 endif
 
-.PHONY: all test clean
 
-build-native:
-	@echo "Build options: $(BUILD_OPTS)"
-	@docker build \
-	$(BUILD_OPTS) \
-	-t $(PROJECT_BASE):$(VERSION) \
-	-t $(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL) \
-	.
-	@docker build \
-	$(BUILD_OPTS) \
-	-t $(PROJECT_BASE):$(VERSION)-alpine \
-	-t $(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL)-alpine \
-	-f Dockerfile.alpine \
-	.
+.PHONY: all test clean
 
 build-multiarch: _prepare-multiarch
 	@echo "Build multiarch options: $(BUILD_OPTS)"
+	@echo "Buildx args: $(BUILDX_ARG_PUSH)"	
 	@docker buildx build \
 	$(BUILD_OPTS) \
 	--platform linux/amd64,linux/arm64 \
 	$(BUILDX_ARG_PUSH) \
-	-t "$(PROJECT_BASE):$(VERSION)-ma" \
-	-t "$(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL)-ma" \
+	-t "$(PROJECT_BASE):$(VERSION)" \
+	-t "$(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL)" \
 	.
 	@docker buildx build \
 	$(BUILD_OPTS) \
 	--platform linux/amd64,linux/arm64 \
 	$(BUILDX_ARG_PUSH) \
-	-t "$(PROJECT_BASE):$(VERSION)-alpine-ma" \
-	-t "$(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL)-alpine-ma" \
+	-t "$(PROJECT_BASE):$(VERSION)-alpine" \
+	-t "$(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL)-alpine" \
 	-f Dockerfile.alpine \
 	.
 
-build: build-native build-multiarch
+build: build-multiarch
 
 test:
 	@echo "Testing standard image..."
@@ -62,17 +51,12 @@ test:
 	-v `pwd`/test:/var/test \
 	$(PROJECT_BASE):$(VERSION) \
 	go run /var/test/mustcompile/mustcompile.go -version="$(MAJOR).$(MINOR).$(PATCH)"
+
 	@echo "Testing alpine image..."
 	docker run --rm \
 	-v `pwd`/test:/var/test \
 	$(PROJECT_BASE):$(VERSION)-alpine \
 	go run /var/test/mustcompile/mustcompile.go -version="$(MAJOR).$(MINOR).$(PATCH)"
-
-publish:
-	@docker push $(PROJECT_BASE):$(VERSION)
-	@docker push $(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL)
-	@docker push $(PROJECT_BASE):$(VERSION)-alpine
-	@docker push $(PROJECT_BASE):$(MAJOR).$(MINOR)$(LABEL)-alpine
 
 ################
 # Helper rules #

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,4 +2,4 @@
 VERSION=`cat .version`
 
 make build BUILD_SCOPE=${VERSION} PUSH_MULTIARCH=true
-make publish BUILD_SCOPE=${VERSION}
+


### PR DESCRIPTION
Simplify image building and publish by pushing only multi-arch image with single task with `--push`

Makes is easier to migrate to arm64 when you do not have to change FROM image tag. Just using the below is enough.
```
FROM --platform=$BUILDPLATFORM vungle/golang:1.22 AS builder
```

Added Github Actions Workflow to build the images when there is a push to master. This will cut external system from time to time pipeline.

Added workflow also to do multi-arch test for images.